### PR TITLE
Add new CLI option --all-branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,3 @@ only show the latest version changes up until it was removed.
 - remove bundler dep
 - add yard doc
 - do not print the warning text if there were no more changes in the lock file
-- find version with the longest length and pad all others to match it (f.i. rails has 4.2.8 and 4.2.7.1)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://travis-ci.org/serch/gistory.svg?branch=master)](https://travis-ci.org/serch/gistory)
 [![Coverage Status](https://coveralls.io/repos/github/serch/gistory/badge.svg?branch=master)](https://coveralls.io/github/serch/gistory?branch=master)
 
-If you use bundler and git, and want to know when a gem you are using was updated, `gistory` comes to your rescue, simply:
+If you use bundler and git and you want to know when a gem was updated, `gistory` comes to the rescue, simply:
 
 ```shell
 gem install gistory
@@ -14,6 +14,7 @@ gistory sidekiq
 ```
 
 and you'll see something like:
+
 ```
 Gem: sidekiq
 Current version: 4.2.7
@@ -25,11 +26,17 @@ Change history:
 4.1.4 on Wed,  9 Nov 2016 14:31 +01:00 (commit 05a3c549)
 ```
 
-By default `gistory` only looks at the last 100 changes to Gemfile.lock
-if you want to see farther in the past run:
+By default `gistory` only looks at the last 100 commits made to the current branch.
+If you want to see farther back in the past run:
 
 ```shell
-gistory sidekiq -m10000
+gistory sidekiq -m1000
+```
+
+If you want to look at all changes to Gemfile.lock in all branches, use the `-a` switch:
+
+```shell
+gistory sidekiq -a
 ```
 
 Note that if the gem was added, then removed, and then added again, `gistory` will

--- a/gistory.gemspec
+++ b/gistory.gemspec
@@ -27,6 +27,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'bundler', '~> 1.0'
   spec.add_dependency 'colorize'
 
+  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.9'
   spec.add_development_dependency 'rubocop'

--- a/lib/gistory/change_log.rb
+++ b/lib/gistory/change_log.rb
@@ -10,17 +10,17 @@ module Gistory
 
     def changelog_for_gem(gem_name)
       version_changes = []
-      lockfile_changes = @repo.changes_to_file(LOCKFILE)
+      commits_with_changes = @repo.changes_to_file(LOCKFILE)
 
       # no lockfile found or no changes to the lockfile found
-      return [] if lockfile_changes.empty?
+      return [] if commits_with_changes.empty?
 
-      previous_commit = lockfile_changes.shift
+      previous_commit = commits_with_changes.shift
       previous_gem_spec = gem_version_at_commit_hash(previous_commit.short_hash, gem_name)
       # only one change to the lockfile was found and the gem was not there
       return [] if previous_gem_spec.nil?
 
-      lockfile_changes.each do |current_commit|
+      commits_with_changes.each do |current_commit|
         current_gem_spec = gem_version_at_commit_hash(current_commit.short_hash, gem_name)
 
         # we reached the end, the gem didn't exist back then

--- a/lib/gistory/cli/arg_parser.rb
+++ b/lib/gistory/cli/arg_parser.rb
@@ -65,7 +65,7 @@ module Gistory
       def add_use_commits_from_all_branches(parser, config)
         description = 'use commits from all branches ' \
                       '(by default it uses only commits made to the current branch)'
-        parser.on('-a', '--all-commits', description) do |a|
+        parser.on('-a', '--all-branches', description) do |a|
           config.all_branches = a
         end
       end

--- a/lib/gistory/cli/arg_parser.rb
+++ b/lib/gistory/cli/arg_parser.rb
@@ -38,24 +38,17 @@ module Gistory
         parser = OptionParser.new
         parser.banner = 'Usage: gistory <gem_name> [options]'
 
-        add_specific_options(parser, config)
-        add_common_options(parser)
+        add_options(parser, config)
 
         parser
       end
 
-      def add_specific_options(parser, config)
+      def add_options(parser, config)
         parser.separator ''
-        parser.separator 'Specific options:'
+        parser.separator 'Options:'
 
         add_max_lockfile_changes(parser, config)
         add_use_commits_from_all_branches(parser, config)
-      end
-
-      def add_common_options(parser)
-        parser.separator ''
-        parser.separator 'Common options:'
-
         add_help(parser)
         add_version(parser)
       end
@@ -71,7 +64,8 @@ module Gistory
 
       def add_use_commits_from_all_branches(parser, config)
         default = config.all_commits
-        description = "use comits from all branches (default #{default})"
+        description = 'use commits from all branches ' \
+                      "(by default it uses only commits made to the current branch)"
         parser.on('-a', '--all-commits', description) do |a|
           config.all_commits = a
         end

--- a/lib/gistory/cli/arg_parser.rb
+++ b/lib/gistory/cli/arg_parser.rb
@@ -66,7 +66,7 @@ module Gistory
         description = 'use commits from all branches ' \
                       '(by default it uses only commits made to the current branch)'
         parser.on('-a', '--all-commits', description) do |a|
-          config.all_commits = a
+          config.all_branches = a
         end
       end
 

--- a/lib/gistory/cli/arg_parser.rb
+++ b/lib/gistory/cli/arg_parser.rb
@@ -47,18 +47,18 @@ module Gistory
         parser.separator ''
         parser.separator 'Options:'
 
-        add_max_lockfile_changes(parser, config)
+        add_max_fetched_commits(parser, config)
         add_use_commits_from_all_branches(parser, config)
         add_help(parser)
         add_version(parser)
       end
 
-      def add_max_lockfile_changes(parser, config)
-        default = config.max_lockfile_changes
-        description = "max number of changes to the lock file (default #{default})"
-        parser.on('-m', '--max-lockfile-changes [INTEGER]', Integer, description) do |m|
-          raise(Gistory::ParserError, 'argument --max-lockfile-changes must be an integer') if m.nil?
-          config.max_lockfile_changes = m
+      def add_max_fetched_commits(parser, config)
+        default = config.max_fetched_commits
+        description = "max number of commits to be fetched (default #{default})"
+        parser.on('-m', '--max-fetched-commits [Integer]', Integer, description) do |m|
+          raise(Gistory::ParserError, 'argument --max-fetched-commits must be an integer') if m.nil?
+          config.max_fetched_commits = m
         end
       end
 

--- a/lib/gistory/cli/arg_parser.rb
+++ b/lib/gistory/cli/arg_parser.rb
@@ -49,6 +49,7 @@ module Gistory
         parser.separator 'Specific options:'
 
         add_max_lockfile_changes(parser, config)
+        add_use_commits_from_all_branches(parser, config)
       end
 
       def add_common_options(parser)
@@ -65,6 +66,14 @@ module Gistory
         parser.on('-m', '--max-lockfile-changes [INTEGER]', Integer, description) do |m|
           raise(Gistory::ParserError, 'argument --max-lockfile-changes must be an integer') if m.nil?
           config.max_lockfile_changes = m
+        end
+      end
+
+      def add_use_commits_from_all_branches(parser, config)
+        default = config.all_commits
+        description = "use comits from all branches (default #{default})"
+        parser.on('-a', '--all-commits', description) do |a|
+          config.all_commits = a
         end
       end
 

--- a/lib/gistory/cli/arg_parser.rb
+++ b/lib/gistory/cli/arg_parser.rb
@@ -63,9 +63,8 @@ module Gistory
       end
 
       def add_use_commits_from_all_branches(parser, config)
-        default = config.all_commits
         description = 'use commits from all branches ' \
-                      "(by default it uses only commits made to the current branch)"
+                      '(by default it uses only commits made to the current branch)'
         parser.on('-a', '--all-commits', description) do |a|
           config.all_commits = a
         end

--- a/lib/gistory/cli/main.rb
+++ b/lib/gistory/cli/main.rb
@@ -35,8 +35,10 @@ module Gistory
         @io.puts ''
 
         @io.puts 'Change history:'
+        max_length = changes.map { |c| c.version.length }.max
         changes.each do |change|
-          @io.puts "#{change.version} on #{change.date.strftime('%a, %e %b %Y %H:%M %Z')} (commit #{change.short_hash})"
+          @io.puts "#{change.version.ljust(max_length)} on #{change.date.strftime('%a, %e %b %Y %H:%M %Z')} " \
+                   "(commit #{change.short_hash})"
         end
 
         @io.puts ''

--- a/lib/gistory/cli/main.rb
+++ b/lib/gistory/cli/main.rb
@@ -44,7 +44,7 @@ module Gistory
         @io.puts ''
 
         max = Gistory.config.max_fetched_commits
-        if Gistory.config.all_commits?
+        if Gistory.config.all_branches?
           @io.puts "The last #{max} changes to the lock file were fetched."
         else
           @io.puts "The last #{max} commits made to the current branch were fetched."

--- a/lib/gistory/cli/main.rb
+++ b/lib/gistory/cli/main.rb
@@ -40,9 +40,15 @@ module Gistory
         end
 
         @io.puts ''
+
         max = Gistory.config.max_lockfile_changes
-        @io.puts "The last #{max} changes to the lock file were taken into account, " \
-                 'to see farther in the past use the -m switch'
+        if Gistory.config.all_commits?
+          @io.puts "The last #{max} changes to the lock file were fetched."
+        else
+          @io.puts "The last #{max} commits made to the current branch were fetched."
+        end
+
+        @io.puts 'To see farther in the past use the -m switch'
       end
     end
   end

--- a/lib/gistory/cli/main.rb
+++ b/lib/gistory/cli/main.rb
@@ -41,7 +41,7 @@ module Gistory
 
         @io.puts ''
 
-        max = Gistory.config.max_lockfile_changes
+        max = Gistory.config.max_fetched_commits
         if Gistory.config.all_commits?
           @io.puts "The last #{max} changes to the lock file were fetched."
         else

--- a/lib/gistory/cli/main.rb
+++ b/lib/gistory/cli/main.rb
@@ -34,15 +34,24 @@ module Gistory
         @io.puts "Current version: #{changes.first.version}"
         @io.puts ''
 
+        print_change_history(changes)
+
+        @io.puts ''
+
+        print_configuration_info
+      end
+
+      def print_change_history(changes)
         @io.puts 'Change history:'
         max_length = changes.map { |c| c.version.length }.max
+
         changes.each do |change|
           @io.puts "#{change.version.ljust(max_length)} on #{change.date.strftime('%a, %e %b %Y %H:%M %Z')} " \
                    "(commit #{change.short_hash})"
         end
+      end
 
-        @io.puts ''
-
+      def print_configuration_info
         max = Gistory.config.max_fetched_commits
         if Gistory.config.all_branches?
           @io.puts "The last #{max} changes to the lock file were fetched."

--- a/lib/gistory/commit.rb
+++ b/lib/gistory/commit.rb
@@ -11,5 +11,9 @@ module Gistory
       @date = DateTime.parse(date.to_s)
       freeze
     end
+
+    def to_s
+      "Commit #{short_hash} on #{date}"
+    end
   end
 end

--- a/lib/gistory/configuration.rb
+++ b/lib/gistory/configuration.rb
@@ -2,10 +2,11 @@
 
 module Gistory
   class Configuration
-    attr_accessor :gem_name, :max_lockfile_changes
+    attr_accessor :gem_name, :max_lockfile_changes, :all_commits
 
     def initialize
       @max_lockfile_changes = 100
+      @all_commits = false
     end
   end
 end

--- a/lib/gistory/configuration.rb
+++ b/lib/gistory/configuration.rb
@@ -2,11 +2,11 @@
 
 module Gistory
   class Configuration
-    attr_accessor :gem_name, :max_lockfile_changes
+    attr_accessor :gem_name, :max_fetched_commits
     attr_writer :all_commits
 
     def initialize
-      @max_lockfile_changes = 100
+      @max_fetched_commits = 100
       @all_commits = false
     end
 

--- a/lib/gistory/configuration.rb
+++ b/lib/gistory/configuration.rb
@@ -3,15 +3,15 @@
 module Gistory
   class Configuration
     attr_accessor :gem_name, :max_fetched_commits
-    attr_writer :all_commits
+    attr_writer :all_branches
 
     def initialize
       @max_fetched_commits = 100
-      @all_commits = false
+      @all_branches = false
     end
 
-    def all_commits?
-      @all_commits
+    def all_branches?
+      @all_branches
     end
   end
 end

--- a/lib/gistory/configuration.rb
+++ b/lib/gistory/configuration.rb
@@ -2,11 +2,16 @@
 
 module Gistory
   class Configuration
-    attr_accessor :gem_name, :max_lockfile_changes, :all_commits
+    attr_accessor :gem_name, :max_lockfile_changes
+    attr_writer :all_commits
 
     def initialize
       @max_lockfile_changes = 100
       @all_commits = false
+    end
+
+    def all_commits?
+      @all_commits
     end
   end
 end

--- a/lib/gistory/git_repo.rb
+++ b/lib/gistory/git_repo.rb
@@ -23,7 +23,7 @@ module Gistory
     private
 
     def git_log_strategy(filename)
-      if Gistory.config.all_commits?
+      if Gistory.config.all_branches?
         "--follow #{filename}"
       else
         # TODO: filter out commits that did not introduce changes to the lock file

--- a/lib/gistory/git_repo.rb
+++ b/lib/gistory/git_repo.rb
@@ -26,6 +26,7 @@ module Gistory
       if Gistory.config.all_commits?
         "--follow #{filename}"
       else
+        # TODO: filter out commits that did not introduce changes to the lock file
         '--first-parent'
       end
     end

--- a/lib/gistory/git_repo.rb
+++ b/lib/gistory/git_repo.rb
@@ -11,7 +11,8 @@ module Gistory
 
     def changes_to_file(filename)
       max_count = Gistory.config.max_lockfile_changes
-      hashes_and_dates = git("log --pretty=format:'%h|%cD' --max-count=#{max_count} --follow #{filename}")
+      strategy = git_log_strategy(filename)
+      hashes_and_dates = git("log --pretty=format:'%h|%cD' --max-count=#{max_count} #{strategy}")
       to_commits(hashes_and_dates.split("\n"))
     end
 
@@ -20,6 +21,14 @@ module Gistory
     end
 
     private
+
+    def git_log_strategy(filename)
+      if Gistory.config.all_commits?
+        "--follow #{filename}"
+      else
+        '--first-parent'
+      end
+    end
 
     def git_cli_available?
       system('which git > /dev/null 2>&1')

--- a/lib/gistory/git_repo.rb
+++ b/lib/gistory/git_repo.rb
@@ -10,7 +10,7 @@ module Gistory
     end
 
     def changes_to_file(filename)
-      max_count = Gistory.config.max_lockfile_changes
+      max_count = Gistory.config.max_fetched_commits
       strategy = git_log_strategy(filename)
       hashes_and_dates = git("log --pretty=format:'%h|%cD' --max-count=#{max_count} #{strategy}")
       to_commits(hashes_and_dates.split("\n"))

--- a/lib/gistory/version_change.rb
+++ b/lib/gistory/version_change.rb
@@ -14,5 +14,9 @@ module Gistory
       @version = version
       freeze
     end
+
+    def to_s
+      "Version #{version} (on #{date} by #{short_hash})"
+    end
   end
 end

--- a/spec/gistory/cli/arg_parser_spec.rb
+++ b/spec/gistory/cli/arg_parser_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe Gistory::Cli::ArgParser do
       expect(config.gem_name).to eq('mygem')
     end
 
-    it 'parses max_lockfile_changes' do
+    it 'parses max_fetched_commits' do
       parser = described_class.new(args: ['mygem', '-m10'])
       config = parser.parse
       expect(config.gem_name).to eq('mygem')
-      expect(config.max_lockfile_changes).to eq(10)
+      expect(config.max_fetched_commits).to eq(10)
     end
 
     it 'raises when no arguments are passed' do
@@ -21,7 +21,7 @@ RSpec.describe Gistory::Cli::ArgParser do
     end
 
     it 'raises when no gem name is passed' do
-      parser = described_class.new(args: ['--max-lockfile-changes', '10'])
+      parser = described_class.new(args: ['--max-fetched-commits', '10'])
       expect { parser.parse }.to raise_error(Gistory::ParserError)
     end
 
@@ -30,7 +30,7 @@ RSpec.describe Gistory::Cli::ArgParser do
       expect { parser.parse }.to raise_error(Gistory::ParserError)
     end
 
-    it 'raises when max_lockfile_changes is not an integer' do
+    it 'raises when max_fetched_commits is not an integer' do
       parser = described_class.new(args: ['mygem', '-mA'])
       expect { parser.parse }.to raise_error(Gistory::ParserError)
     end


### PR DESCRIPTION
Adds new CLI option `--all-branches` to fetch commits from all branches.
By default `gistory` now fetches commits made only to the current branch.