### PR TITLE
Add option --hashes-only to output only commit hashes so they can be piped

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 require: rubocop-rspec
 
 AllCops:
+  TargetRubyVersion: 2.4
   NewCops: enable
 
 Metrics/AbcSize:

--- a/Gemfile
+++ b/Gemfile
@@ -4,12 +4,6 @@ source "https://rubygems.org"
 
 gemspec
 
-group :development, :test do
-  gem "byebug"
-  gem "pry", "~> 0.13.1"
-  gem "pry-byebug", "~> 3.9.0"
-end
-
 group :test do
   gem "coveralls", require: false
   gem "simplecov", require: false # code coverage

--- a/lib/gistory/cli/arg_parser.rb
+++ b/lib/gistory/cli/arg_parser.rb
@@ -50,6 +50,7 @@ module Gistory
 
         add_max_fetched_commits(parser, config)
         add_use_commits_from_all_branches(parser, config)
+        add_output_commit_hashes_only(parser, config)
         add_help(parser)
         add_version(parser)
       end
@@ -69,6 +70,15 @@ module Gistory
                       "(by default it uses only commits made to the current branch)"
         parser.on("-a", "--all-branches", description) do |a|
           config.all_branches = a
+        end
+      end
+
+      def add_output_commit_hashes_only(parser, config)
+        option_switch = "--hashes-only"
+        parser.on(option_switch,
+                  "output commit hashes only so they can be piped",
+                  "for example: gistory #{option_switch} sidekiq | xargs git show") do |ho|
+          config.output_commit_hashes_only = ho
         end
       end
 

--- a/lib/gistory/cli/main.rb
+++ b/lib/gistory/cli/main.rb
@@ -30,6 +30,18 @@ module Gistory
           raise(Gistory::Error, "Gem '#{gem_name}' not found in lock file, maybe a typo?")
         end
 
+        if Gistory.config.output_commit_hashes_only?
+          print_commit_hashes_only(changes)
+        else
+          print_full_output(gem_name, changes)
+        end
+      end
+
+      def print_commit_hashes_only(changes)
+        changes.each { |change| @io.puts change.short_hash }
+      end
+
+      def print_full_output(gem_name, changes)
         @io.puts "Gem: #{gem_name}"
         @io.puts "Current version: #{changes.first.version}"
         @io.puts ""

--- a/lib/gistory/configuration.rb
+++ b/lib/gistory/configuration.rb
@@ -3,15 +3,20 @@
 module Gistory
   class Configuration
     attr_accessor :gem_name, :max_fetched_commits
-    attr_writer :all_branches
+    attr_writer :all_branches, :output_commit_hashes_only
 
     def initialize
       @max_fetched_commits = 100
       @all_branches = false
+      @output_commit_hashes_only = false
     end
 
     def all_branches?
       @all_branches
+    end
+
+    def output_commit_hashes_only?
+      @output_commit_hashes_only
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/serch/gistory/issues/6

Adds option --hashes-only to output just the commit hashes, this way we can pipe gistory's output like so:

`gistory --hashes-only sidekiq | xargs git show`